### PR TITLE
Add option to use X colors

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import argparse
 from threading import Thread
 from pynput.mouse import Button, Controller
 from queue import Queue
@@ -70,6 +71,12 @@ def create_cache():
         mkdir(CACHE_DIR)
 
 
+# Command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("-x", "--xcolors", action="store_true", default=False,
+                    help="use X colors")
+args = parser.parse_args()
+
 queue = Queue()
 image_queue = ImageQueue()
 
@@ -77,7 +84,7 @@ image_queue = ImageQueue()
 interactions = Interactions(sp, token_info, sp_oauth, exit_app, queue)
 
 # UI
-ui = Ui(interactions)
+ui = Ui(interactions, use_x_colors=args.xcolors)
 
 # Create icon
 icon = QIcon(f"{ASSETS_DIR}img{sep}logo_small.png")

--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ def create_cache():
 # Command line arguments
 parser = argparse.ArgumentParser()
 parser.add_argument("-x", "--xcolors", action="store_true", default=False,
-                    help="use X colors")
+                    help="use X colors (Linux only)")
 args = parser.parse_args()
 
 queue = Queue()


### PR DESCRIPTION
Added `argparse` and an argument:
```
$ python app.py -h
usage: app.py [-h] [-x]

optional arguments:
  -h, --help     show this help message and exit
  -x, --xcolors  use X colors (Linux only)
```

`python app.py -x` makes the UI use the colors defined in your X resources, gathered via `xrdb`. Especially useful if you want to theme `spotlightify` via a tool like [pywal](https://github.com/dylanaraps/pywal).

[Video demonstration](https://streamable.com/jatjom)
As you can see the UI of `spotlightify` is colored according to the wallpaper/terminals colors.

Requirements:
* Linux (is checked in code)
* Restart of `spotlightify` on X colors change, as the UI is created only once, and therefore the colors are sourced only once. For a live change a different method could be used, but it's trivial to have `spotlightify` automatically restart whenever you change your X colors.