### PR TITLE
Update app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,7 +143,7 @@ class App:
     @staticmethod
     def exit():
         print(f"\n{colors.PINK}{colors.BOLD}Exiting{colors.RESET}")
-        kill(getpid(), 9)
+        kill(getpid(), 3)
         exit(0)
 
 


### PR DESCRIPTION
The exit function shouldn't be using a kill -9 as this should be used as a large resort when killing a process on a *NIX system.

kill -3, or kill (pid) is a better way to kill a process.