### PR TITLE
Make Spotlightify work with a free subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Spotlightify
+# SpotlightifyFree
 
-Spotlightify is a GUI based application designed to allow users to quickly interact with the Spotify Desktop application across Windows, Linux and macOS.
+Spotlightify is a GUI based application designed to allow users to quickly interact with the Spotify Desktop application across Windows, Linux and macOS. This is a fork that allows you to use this with a Spotify Free subscription.
 
 ![Spotlightify](preview.gif)
 
 ## Prerequisites
 
--   Spotify Premium Account
+-   ~~Spotify Premium Account~~
+-   You must have logged into open.spotify.com through Google Chrome. This is for using cookies to manage playback.
 -   Python 3.7 or later
 -   A Spotify App must also be created, the instructions follow:
     1. Open the Spotify Developer Dashboard <a href="https://developer.spotify.com/dashboard/login" target="_blank">here</a> and login using your Spotify account credentials.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SpotlightifyFree
 
-Spotlightify is a GUI based application designed to allow users to quickly interact with the Spotify Desktop application across Windows, Linux and macOS. This is a fork that allows you to use this with a Spotify Free subscription.
+Spotlightify is a GUI based application designed to allow users to quickly interact with the Spotify Desktop application across Windows, Linux and macOS. This is an update that allows you to use this with a Spotify Free subscription.
 
 ![Spotlightify](preview.gif)
 
 ## Prerequisites
 
 -   ~~Spotify Premium Account~~
--   You must have logged into open.spotify.com through Google Chrome. This is for using cookies to manage playback.
+-   You must have logged into open.spotify.com through Google Chrome. This is for using cookies to manage playback. If you haven't, the default playback commands will run, which don't work with a free Spotify subscription.
 -   Python 3.7 or later
 -   A Spotify App must also be created, the instructions follow:
     1. Open the Spotify Developer Dashboard <a href="https://developer.spotify.com/dashboard/login" target="_blank">here</a> and login using your Spotify account credentials.

--- a/api/manager.py
+++ b/api/manager.py
@@ -8,13 +8,13 @@ from api import misc, play, playback, toggle, check
 
 
 class PlaybackManager:
-    def __init__(self, sp: spotipy.Spotify, queue: Queue):
+    def __init__(self, sp: spotipy.Spotify, queue: Queue, spotifyplayer):
         self.sp = sp
-        self._playback = playback.PlaybackFunctions(sp)
-        self._play = play.PlayFunctions(sp, queue)
-        self._toggle = toggle.ToggleFunctions(sp)
+        self._playback = playback.PlaybackFunctions(sp, spotifyplayer)
+        self._play = play.PlayFunctions(sp, queue, spotifyplayer)
+        self._toggle = toggle.ToggleFunctions(sp, spotifyplayer)
         self._check = check.CheckFunctions(sp)
-        self._misc = misc.MiscFunctions(sp)
+        self._misc = misc.MiscFunctions(sp, spotifyplayer)
 
     def pause(self):
         self._playback.pause()

--- a/api/misc.py
+++ b/api/misc.py
@@ -5,7 +5,8 @@ from api.limiter import Limiter
 
 
 class MiscFunctions:
-    def __init__(self, sp: spotipy.Spotify):
+    def __init__(self, sp: spotipy.Spotify, spotifyplayer):
+        self.spotifyplayer = spotifyplayer
         self.sp = sp
 
     @Limiter.rate_limiter(seconds=10)
@@ -18,14 +19,14 @@ class MiscFunctions:
 
     def set_device(self, id_: str):
         try:
-            self.sp.transfer_playback(id_, True)
+            self.spotifyplayer.transfer(id_)
         except:
             None
 
     def set_default_device(self):
         try:
             device_id = self.sp.devices()["devices"][0]["id"]
-            self.sp.transfer_playback(device_id, True)
+            self.spotifyplayer.transfer(device_id)
         except:
             print("[Error] could not select default device.")
 
@@ -36,7 +37,7 @@ class MiscFunctions:
         '''
         try:
             if 1 <= value <= 10:
-                self.sp.volume(value*10)
+                self.spotifyplayer.command(self.spotifyplayer.volume(int(value) * 10))
             else:
                 raise Exception
         except:

--- a/api/misc.py
+++ b/api/misc.py
@@ -19,14 +19,20 @@ class MiscFunctions:
 
     def set_device(self, id_: str):
         try:
-            self.spotifyplayer.transfer(id_)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.transfer(id_)
+            else:
+                self.sp.transfer_playback(id_, True)
         except:
             None
 
     def set_default_device(self):
         try:
             device_id = self.sp.devices()["devices"][0]["id"]
-            self.spotifyplayer.transfer(device_id)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.transfer(device_id)
+            else:
+                self.sp.transfer_playback(device_id, True)
         except:
             print("[Error] could not select default device.")
 
@@ -37,7 +43,10 @@ class MiscFunctions:
         '''
         try:
             if 1 <= value <= 10:
-                self.spotifyplayer.command(self.spotifyplayer.volume(int(value) * 10))
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.volume(int(value) * 10))
+                else:
+                    self.sp.volume(value * 10)
             else:
                 raise Exception
         except:

--- a/api/play.py
+++ b/api/play.py
@@ -5,15 +5,16 @@ from caching.holder import CacheHolder
 
 
 class PlayFunctions:
-    def __init__(self, sp: spotipy.Spotify, queue: Queue):
+    def __init__(self, sp: spotipy.Spotify, queue: Queue, spotifyplayer):
         self.sp = sp
+        self.spotifyplayer = spotifyplayer
         self.__queue = queue
 
     def term(self, term: str):
         try:
             track = self.sp.search(term, limit=1, market="GB", type="track")["tracks"]["items"][0]
             uri = track["uri"]
-            self.sp.start_playback(uris=[uri])
+            self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
             self.__queue.put(track)
         except:
             print("[Error] Could not play song from term inputted")
@@ -21,9 +22,9 @@ class PlayFunctions:
     def uri(self, uri: str):
         try:
             if "track" not in uri:
-                self.sp.start_playback(context_uri=uri)
+                self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
             else:
-                self.sp.start_playback(uris=[uri])
+                self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
                 track = self.sp.track(uri)
                 self.__queue.put(track)
         except:
@@ -33,11 +34,11 @@ class PlayFunctions:
         try:
             uri = f"spotify:{type_}:{id_}"
             if type_ == "track":
-                self.sp.start_playback(uris=[uri])
+                self.spotifyplayer.command(self.spotifyplayer.play(id_))
                 track = self.sp.track(uri)
                 self.__queue.put(track)
             else:
-                self.sp.start_playback(context_uri=uri)
+                self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
         except:
             print(f"[Error] Could not play {type_} from ID")
 
@@ -57,13 +58,13 @@ class PlayFunctions:
             for track in values:
                 uris.append(f"spotify:track:{track[0]}")
 
-            self.sp.start_playback(uris=uris)
+            self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
         except:
             print("[Error] Could not play liked music")
 
     def queue_uri(self, uri: str):
         try:
-            self.sp.add_to_queue(uri)
+            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
             track = self.sp.track(uri)
             self.__queue.put(track)
         except:
@@ -72,7 +73,7 @@ class PlayFunctions:
     def queue_id(self, id_: str):
         try:
             uri = f"spotify:track:{id_}"
-            self.sp.add_to_queue(uri=uri)
+            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(id_))
             track = self.sp.track(uri)
             self.__queue.put(track)
         except:
@@ -82,7 +83,7 @@ class PlayFunctions:
         try:
             track = self.sp.search(term, limit=1, market="GB", type="track")["tracks"]["items"][0]
             uri = track["uri"]
-            self.sp.add_to_queue(uri=uri)
+            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
             self.__queue.put(track)
         except:
             print("[Error] Could not queue song from term inputted")
@@ -94,6 +95,6 @@ class PlayFunctions:
             results = self.sp.recommendations(seed_tracks=[track["id"]], limit=50)
             print(results)
             uris = [track["uri"] for track in results["tracks"]]
-            self.sp.start_playback(uris=uris)
+            self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
         except:
             print(f"[Error] Could not play recommended songs")

--- a/api/play.py
+++ b/api/play.py
@@ -120,7 +120,6 @@ class PlayFunctions:
             track = self.sp.track(id_)
             #uri = f"spotify:track:{id_}"
             results = self.sp.recommendations(seed_tracks=[track["id"]], limit=50)
-            print(results)
             uris = [track["uri"] for track in results["tracks"]]
             if self.spotifyplayer.isinitialized:
                 self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))

--- a/api/play.py
+++ b/api/play.py
@@ -14,7 +14,10 @@ class PlayFunctions:
         try:
             track = self.sp.search(term, limit=1, market="GB", type="track")["tracks"]["items"][0]
             uri = track["uri"]
-            self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
+            else:
+                self.sp.start_playback(uris=[uri])
             self.__queue.put(track)
         except:
             print("[Error] Could not play song from term inputted")
@@ -22,9 +25,15 @@ class PlayFunctions:
     def uri(self, uri: str):
         try:
             if "track" not in uri:
-                self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
+                else:
+                    self.sp.start_playback(context_uri=uri)
             else:
-                self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.play(uri.split(':')[-1]))
+                else:
+                    self.sp.start_playback(uris=[uri])
                 track = self.sp.track(uri)
                 self.__queue.put(track)
         except:
@@ -34,11 +43,17 @@ class PlayFunctions:
         try:
             uri = f"spotify:{type_}:{id_}"
             if type_ == "track":
-                self.spotifyplayer.command(self.spotifyplayer.play(id_))
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.play(id_))
+                else:
+                    self.sp.start_playback(uris=[uri])
                 track = self.sp.track(uri)
                 self.__queue.put(track)
             else:
-                self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.play_from_context(uri))
+                else:
+                    self.sp.start_playback(context_uri=uri)
         except:
             print(f"[Error] Could not play {type_} from ID")
 
@@ -58,13 +73,19 @@ class PlayFunctions:
             for track in values:
                 uris.append(f"spotify:track:{track[0]}")
 
-            self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
+            else:
+                self.sp.start_playback(uris=uris)
         except:
             print("[Error] Could not play liked music")
 
     def queue_uri(self, uri: str):
         try:
-            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
+            else:
+                self.sp.add_to_queue(uri)
             track = self.sp.track(uri)
             self.__queue.put(track)
         except:
@@ -73,7 +94,10 @@ class PlayFunctions:
     def queue_id(self, id_: str):
         try:
             uri = f"spotify:track:{id_}"
-            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(id_))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.add_to_queue(id_))
+            else:
+                self.sp.add_to_queue(uri)
             track = self.sp.track(uri)
             self.__queue.put(track)
         except:
@@ -83,7 +107,10 @@ class PlayFunctions:
         try:
             track = self.sp.search(term, limit=1, market="GB", type="track")["tracks"]["items"][0]
             uri = track["uri"]
-            self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.add_to_queue(uri.split(':')[-1]))
+            else:
+                self.sp.add_to_queue(uri=uri)
             self.__queue.put(track)
         except:
             print("[Error] Could not queue song from term inputted")
@@ -95,6 +122,9 @@ class PlayFunctions:
             results = self.sp.recommendations(seed_tracks=[track["id"]], limit=50)
             print(results)
             uris = [track["uri"] for track in results["tracks"]]
-            self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.play_from_uris(uris))
+            else:
+                self.sp.start_playback(uris=uris)
         except:
             print(f"[Error] Could not play recommended songs")

--- a/api/playback.py
+++ b/api/playback.py
@@ -3,30 +3,31 @@ from api.limiter import Limiter
 
 
 class PlaybackFunctions:
-    def __init__(self, sp: spotipy.Spotify):
+    def __init__(self, sp: spotipy.Spotify, spotifyplayer):
         self.sp = sp
+        self.spotifyplayer = spotifyplayer
 
     def skip(self):
         try:
-            self.sp.next_track()
+            self.spotifyplayer.command(self.spotifyplayer.skip)
         except:
             print("[Error] Cannot skip track.")
 
     def pause(self):
         try:
-            self.sp.pause_playback()
+            self.spotifyplayer.command(self.spotifyplayer.pause)
         except:
             print("[Error] Could not pause playback.")
 
     def resume(self):
         try:
-            self.sp.start_playback()
+            self.spotifyplayer.command(self.spotifyplayer.resume)
         except:
             print("[Error] Could not resume playback.")
 
     def previous(self):
         try:
-            self.sp.previous_track()
+            self.spotifyplayer.command(self.spotifyplayer.previous)
         except:
             print("[Error]")
 
@@ -38,14 +39,15 @@ class PlaybackFunctions:
                 time = "0:" + str(time)
             h, m, s = time.split(':')
             time = (int(h) * 3600 + int(m) * 60 + int(s)) * 1000
-            self.sp.seek_track(time)
+            self.spotifyplayer.command(self.spotifyplayer.seek_to(time))
         except:
             print("[Error] Invalid time give. Valid command example: go to 1:40")
 
     @Limiter.rate_limiter(seconds=10)
     def get_current_song_info(self) -> dict:
         try:
-            song = self.sp.current_playback()["item"]
+            song = self.sp.current_user_playing_track()["item"]
+            print(", ".join([artist["name"] for artist in song["artists"]]))
             return {"name": song["name"], "artist": ", ".join([artist["name"] for artist in song["artists"]]),
                     "image": song["album"]["id"]}
         except:

--- a/api/playback.py
+++ b/api/playback.py
@@ -9,25 +9,37 @@ class PlaybackFunctions:
 
     def skip(self):
         try:
-            self.spotifyplayer.command(self.spotifyplayer.skip)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.skip)
+            else:
+                self.sp.next_track()
         except:
             print("[Error] Cannot skip track.")
 
     def pause(self):
         try:
-            self.spotifyplayer.command(self.spotifyplayer.pause)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.pause)
+            else:
+                self.sp.pause_playback()
         except:
             print("[Error] Could not pause playback.")
 
     def resume(self):
         try:
-            self.spotifyplayer.command(self.spotifyplayer.resume)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.resume)
+            else:
+                self.sp.start_playback()
         except:
             print("[Error] Could not resume playback.")
 
     def previous(self):
         try:
-            self.spotifyplayer.command(self.spotifyplayer.previous)
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.previous)
+            else:
+                self.sp.previous_track()
         except:
             print("[Error]")
 
@@ -39,7 +51,10 @@ class PlaybackFunctions:
                 time = "0:" + str(time)
             h, m, s = time.split(':')
             time = (int(h) * 3600 + int(m) * 60 + int(s)) * 1000
-            self.spotifyplayer.command(self.spotifyplayer.seek_to(time))
+            if self.spotifyplayer.isinitialized:
+                self.spotifyplayer.command(self.spotifyplayer.seek_to(time))
+            else:
+                self.sp.seek_track(time)
         except:
             print("[Error] Invalid time give. Valid command example: go to 1:40")
 

--- a/api/playback.py
+++ b/api/playback.py
@@ -47,7 +47,6 @@ class PlaybackFunctions:
     def get_current_song_info(self) -> dict:
         try:
             song = self.sp.current_user_playing_track()["item"]
-            print(", ".join([artist["name"] for artist in song["artists"]]))
             return {"name": song["name"], "artist": ", ".join([artist["name"] for artist in song["artists"]]),
                     "image": song["album"]["id"]}
         except:

--- a/api/toggle.py
+++ b/api/toggle.py
@@ -24,18 +24,30 @@ class ToggleFunctions:
     def shuffle(self):
         try:
             if self._check.is_shuffle_on():
-                self.spotifyplayer.command(self.spotifyplayer.stop_shuffle())
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.stop_shuffle())
+                else:
+                    self.sp.shuffle(False)
             else:
-                self.spotifyplayer.command(self.spotifyplayer.shuffle())
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.shuffle())
+                else:
+                    self.sp.shuffle(True)
         except:
             print("[Error] Shuffle could not be toggled")
 
     def playback(self):
         try:
             if self._check.is_song_playing():
-                self.spotifyplayer.command(self.spotifyplayer.pause)
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.pause)
+                else:
+                    self.sp.pause_playback()
             else:
-                self.spotifyplayer.command(self.spotifyplayer.resume)
+                if self.spotifyplayer.isinitialized:
+                    self.spotifyplayer.command(self.spotifyplayer.resume)
+                else:
+                    self.sp.start_playback()
         except:
             print("[Error] Playback could not be toggled")
 
@@ -45,11 +57,20 @@ class ToggleFunctions:
             if state == "cycle":
                 repeat_state = self._check.repeat_state()
                 if repeat_state == 'track':
-                    self.spotifyplayer.command(self.spotifyplayer.no_repeat)
+                    if self.spotifyplayer.isinitialized:
+                        self.spotifyplayer.command(self.spotifyplayer.no_repeat)
+                    else:
+                        self.sp.repeat('off')
                 elif repeat_state == 'context':
-                    self.spotifyplayer.command(self.spotifyplayer.repeating_track)
+                    if self.spotifyplayer.isinitialized:
+                        self.spotifyplayer.command(self.spotifyplayer.repeating_track)
+                    else:
+                        self.sp.repeat('track')
                 else:
-                    self.spotifyplayer.command(self.spotifyplayer.repeating_context)
+                    if self.spotifyplayer.isinitialized:
+                        self.spotifyplayer.command(self.spotifyplayer.repeating_context)
+                    else:
+                        self.sp.repeat('context')
             else:
                 self.sp.repeat(state)
         except:

--- a/api/toggle.py
+++ b/api/toggle.py
@@ -3,8 +3,9 @@ from api import check
 
 
 class ToggleFunctions:
-    def __init__(self, sp: spotipy.Spotify):
+    def __init__(self, sp: spotipy.Spotify, player):
         self.sp = sp
+        self.spotifyplayer = player
         self._check = check.CheckFunctions(sp)
 
     def like_song(self):
@@ -23,18 +24,18 @@ class ToggleFunctions:
     def shuffle(self):
         try:
             if self._check.is_shuffle_on():
-                self.sp.shuffle(False)
+                self.spotifyplayer.command(self.spotifyplayer.stop_shuffle())
             else:
-                self.sp.shuffle(True)
+                self.spotifyplayer.command(self.spotifyplayer.shuffle())
         except:
             print("[Error] Shuffle could not be toggled")
 
     def playback(self):
         try:
             if self._check.is_song_playing():
-                self.sp.pause_playback()
+                self.spotifyplayer.command(self.spotifyplayer.pause)
             else:
-                self.sp.start_playback()
+                self.spotifyplayer.command(self.spotifyplayer.resume)
         except:
             print("[Error] Playback could not be toggled")
 
@@ -44,11 +45,11 @@ class ToggleFunctions:
             if state == "cycle":
                 repeat_state = self._check.repeat_state()
                 if repeat_state == 'track':
-                    self.sp.repeat('off')
+                    self.spotifyplayer.command(self.spotifyplayer.no_repeat)
                 elif repeat_state == 'context':
-                    self.sp.repeat('track')
+                    self.spotifyplayer.command(self.spotifyplayer.repeating_track)
                 else:
-                    self.sp.repeat('context')
+                    self.spotifyplayer.command(self.spotifyplayer.repeating_context)
             else:
                 self.sp.repeat(state)
         except:

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import QApplication, QMenu, QAction, QSystemTrayIcon
 from pynput.mouse import Controller, Button
 from spotipy import Spotify
 
+from experimental import SpotifyPlayer
 from api.spotify_singleton import SpotifySingleton
 from auth import AuthUI, config
 from caching import CacheManager, SongQueue, ImageQueue
@@ -47,6 +48,8 @@ class App:
         self.image_queue = None
         self.cache_manager = None
 
+        self.spotifyclient = SpotifyPlayer()
+
         self.run()
 
     def run(self):
@@ -80,7 +83,7 @@ class App:
             self.image_queue = ImageQueue()
             self.cache_manager = CacheManager(self.spotify, self.song_queue, self.image_queue)
 
-            self.spotlight = SpotlightUI(self.spotify, self.song_queue)
+            self.spotlight = SpotlightUI(self.spotify, self.song_queue, self.spotifyclient)
 
             self.show_spotlight()
             while True:

--- a/experimental.py
+++ b/experimental.py
@@ -233,7 +233,7 @@ class SpotifyPlayer:
                                     ['shuffling_context'])
                             except AttributeError:
                                 pass
-                    except websockets.exceptions.ConnectionClosedOK as exc:
+                    except websockets.exceptions.ConnectionClosedError as exc:
                         logging.error(exc, exc_info=False)
                         self.isinitialized = False
                         break

--- a/experimental.py
+++ b/experimental.py
@@ -115,7 +115,7 @@ class SpotifyPlayer:
         return [{'command': {'next_tracks': queue[1:], 'queue_revision': self.queue_revision,
                              'endpoint': 'set_queue'}},
                 {"command": {"context": {"uri": queue[0]['uri'],
-                                         "url": queue[0]['uri'],
+                                         "url": f'context://{queue[0]["uri"]}',
                                          "metadata": {}}, "play_origin":
                                  {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
                                  {"license": "on-demand", "skip_to": {"track_index": 0}, "player_options_override": {}},
@@ -301,7 +301,10 @@ class SpotifyPlayer:
                                                                     {"capabilities": {"can_be_player": False,
                                                                                       "hidden": True}}}}
         response = self._session.put(hobs_url, headers=hobs_headers, data=json.dumps(hobs_data))
-        self.queue = response.json()['player_state']['next_tracks']
+        try:
+            self.queue = response.json()['player_state']['next_tracks']
+        except KeyError:
+            self.queue = []
         self.queue_revision = response.json()['player_state']['queue_revision']
         self.shuffling = response.json()['player_state']['options']['shuffling_context']
 

--- a/experimental.py
+++ b/experimental.py
@@ -164,7 +164,12 @@ class SpotifyPlayer:
                             'endpoint': 'set_queue'}}
 
     def __init__(self):
-        self.cj = browser_cookie3.chrome()
+        self.isinitialized = False
+        try:
+            self.cj = browser_cookie3.chrome()
+            self.isinitialized = True
+        except Exception as e:
+            logging.error(e, exc_info=True)
         self._default_headers = {'sec-fetch-dest': 'empty',
                                  'sec-fetch-mode': 'cors',
                                  'sec-fetch-site': 'same-origin',
@@ -173,7 +178,8 @@ class SpotifyPlayer:
 
         self._session = requests.Session()
         self.shuffling = False
-        self._authorize()
+        if self.isinitialized:
+            self._authorize()
 
     def _authorize(self):
         access_token_headers = self._default_headers.copy()
@@ -276,6 +282,7 @@ class SpotifyPlayer:
         self.queue = response.json()['player_state']['next_tracks']
         self.queue_revision = response.json()['player_state']['queue_revision']
         self.shuffling = response.json()['player_state']['options']['shuffling_context']
+        self.isinitialized = True
 
     def transfer(self, device_id):
         transfer_url = f'https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/' \

--- a/experimental.py
+++ b/experimental.py
@@ -1,0 +1,353 @@
+import browser_cookie3
+import requests
+import websockets
+import asyncio
+import json
+import logging
+import string
+import random
+import time
+
+from threading import Thread
+from requests.exceptions import RequestException
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)-8s - %(name)-14s - %(message)s')
+
+
+class SpotifyPlayer:
+    pause = {'command': {'endpoint': 'pause'}}
+    resume = {'command': {'endpoint': 'resume'}}
+    skip = {'command': {'endpoint': 'skip_next'}}
+    previous = {'command': {'endpoint': 'skip_prev'}}
+    repeating_context = {'command': {'repeating_context': True, 'repeating_track': False, 'endpoint': 'set_options'}}
+    repeating_track = {'command': {'repeating_context': True, 'repeating_track': True, 'endpoint': 'set_options'}}
+    no_repeat = {'command': {'repeating_context': False, 'repeating_track': False, 'endpoint': 'set_options'}}
+
+    def shuffle(self):
+        self.shuffling = True
+        return {'command': {'value': True, 'endpoint': 'set_shuffling_context'}}
+
+    def stop_shuffle(self):
+        self.shuffling = False
+        return {'command': {'value': False, 'endpoint': 'set_shuffling_context'}}
+
+    @staticmethod
+    def volume(volume):
+        return {'volume': volume * 65535 / 100, 'url': 'https://guc-spclient.spotify.com/connect-state/'
+                                                       'v1/connect/volume/from/player/to/device',
+                'request_type': 'PUT'}
+
+    @staticmethod
+    def seek_to(ms):
+        return {'command': {'value': ms, 'endpoint': 'seek_to'}}
+
+    @staticmethod
+    def add_to_queue(track_id):
+        return {'command': {'track': {'uri': f'spotify:track:{track_id}', 'metadata': {'is_queued': True},
+                                      'provider': 'queue'}, 'endpoint': 'add_to_queue'}}
+
+    @staticmethod
+    def play(track_id):
+        return {"command": {"context": {"uri": f"spotify:track:{track_id}",
+                                        "url": f"context://spotify:track:{track_id}",
+                                        "metadata": {}}, "play_origin":
+                                {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
+                                {"license": "on-demand", "skip_to": {"track_index": 0}, "player_options_override": {}},
+                            "endpoint": "play"}}
+
+    def remove_from_queue(self, track_id):
+        matches = ([index for index, track in enumerate(self.queue) if track_id in track['uri']
+                    or 'spotify:ad:' in track['uri']])
+        [self.queue.pop(index) for index in matches]
+        return {'command': {'next_tracks': self.queue, 'queue_revision': self.queue_revision, 'endpoint': 'set_queue'}}
+
+    def clear_queue(self):
+        matches = ([track for track in self.queue if 'queue' != track['provider']])
+        return {'command': {'next_tracks': matches, 'queue_revision': self.queue_revision, 'endpoint': 'set_queue'}}
+
+    def queue_playlist(self, playlist_id):
+        url = f'https://api.spotify.com/v1/playlists/{playlist_id}/tracks'
+        headers = {'Authorization': f'Bearer {self.access_token}'}
+        response = self._session.get(url, headers=headers)
+        ids = [item['track']['id'] for item in response.json()['items']]
+        queue = [{'uri': f'spotify:track:{track_id}', 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                 for track_id in ids]
+        if self.shuffling:
+            random.shuffle(queue)
+        queuequeue = [track for track in self.queue if track['provider'] != 'context']
+        queue = queuequeue + queue
+        print(queue)
+        if ids:
+            return {'command': {'next_tracks': queue, 'queue_revision': self.queue_revision, 'endpoint': 'set_queue'}}
+
+    def play_playlist(self, playlist_id, skip_to=0):
+        url = f'https://api.spotify.com/v1/playlists/{playlist_id}/tracks'
+        headers = {'Authorization': f'Bearer {self.access_token}'}
+        response = self._session.get(url, headers=headers)
+        ids = [item['track']['id'] for item in response.json()['items']]
+        queue = [{'uri': f'spotify:track:{track_id}', 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                 for track_id in ids]
+        if self.shuffling:
+            random.shuffle(queue)
+        queue = queue + self.queue
+        print(queue)
+        if ids:
+            return [{'command': {'next_tracks': queue[1:], 'queue_revision': self.queue_revision,
+                                 'endpoint': 'set_queue'}},
+                    {"command": {"context": {"uri": f"{queue[0]['uri']}",
+                                             "url": f"context://{queue[0]['uri']}",
+                                             "metadata": {}}, "play_origin":
+                                     {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
+                                     {"license": "on-demand", "skip_to": {"track_index": skip_to},
+                                      "player_options_override": {}},
+                                 "endpoint": "play"}}]
+
+    def queue_from_uris(self, uris):
+        queue = [{'uri': uri, 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                 for uri in uris]
+        queuequeue = [track for track in self.queue if track['provider'] != 'context']
+        queue = queuequeue + queue
+        print(queue)
+        return {'command': {'next_tracks': queue, 'queue_revision': self.queue_revision,
+                            'endpoint': 'set_queue'}}
+
+    def play_from_uris(self, uris):
+        queue = [{'uri': uri, 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                 for uri in uris]
+        queue = queue + self.queue
+        print(uris)
+        return [{'command': {'next_tracks': queue[1:], 'queue_revision': self.queue_revision,
+                             'endpoint': 'set_queue'}},
+                {"command": {"context": {"uri": uris[0],
+                                         "url": f'context://{uris[0]}',
+                                         "metadata": {}}, "play_origin":
+                                 {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
+                                 {"license": "on-demand", "skip_to": {"track_index": 0}, "player_options_override": {}},
+                             "endpoint": "play"}}]
+
+    def play_from_context(self, context_uri, skip_to=0):
+        oldqueue = [track for track in self.queue if track['provider'] == 'queue']
+        oldqueue = [{'uri': track['uri'], 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                    for track in oldqueue]
+        self.command(self.clear_queue())
+        self.command({"command": {"context": {"uri": f"{context_uri}",
+                                              "url": f"context://{context_uri}",
+                                              "metadata": {}}, "play_origin":
+                                      {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
+                                      {"license": "on-demand", "skip_to": {"track_index": skip_to},
+                                       "player_options_override": {}},
+                                  "endpoint": "play"}})
+        time.sleep(0.75)
+        context_songs = [track for track in self.queue if track['provider'] == 'context']
+        context_songs = [track for track in context_songs if track['metadata']['iteration'] == '0']
+        context_songs = [{'uri': track['uri'], 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                         for track in context_songs]
+        queue = context_songs + oldqueue
+        return {'command': {'next_tracks': queue, 'queue_revision': self.queue_revision,
+                            'endpoint': 'set_queue'}}
+
+    def queue_from_context(self, context_uri, skip_to=0):
+        oldqueue = [track for track in self.queue if track['provider'] == 'queue']
+        oldqueue = [{'uri': track['uri'], 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                    for track in oldqueue]
+        self.command(self.clear_queue())
+        self.command({"command": {"context": {"uri": f"{context_uri}",
+                                              "url": f"context://{context_uri}",
+                                              "metadata": {}}, "play_origin":
+                                      {"feature_identifier": "harmony", "feature_version": "4.11.0-af0ef98"}, "options":
+                                      {"license": "on-demand", "skip_to": {"track_index": skip_to},
+                                       "player_options_override": {}},
+                                  "endpoint": "play"}})
+        time.sleep(0.75)
+        context_songs = [track for track in self.queue if track['provider'] == 'context']
+        context_songs = [track for track in context_songs if track['metadata']['iteration'] == '0']
+        context_songs = [{'uri': track['uri'], 'metadata': {'is_queued': True}, 'provider': 'queue'}
+                         for track in context_songs]
+        queue = context_songs + oldqueue
+        return {'command': {'next_tracks': queue, 'queue_revision': self.queue_revision,
+                            'endpoint': 'set_queue'}}
+
+    def __init__(self):
+        self.cj = browser_cookie3.chrome()
+        self._default_headers = {'sec-fetch-dest': 'empty',
+                                 'sec-fetch-mode': 'cors',
+                                 'sec-fetch-site': 'same-origin',
+                                 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                                               '(KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36'}
+
+        self._session = requests.Session()
+        self.shuffling = False
+        self._authorize()
+
+    def _authorize(self):
+        access_token_headers = self._default_headers.copy()
+        access_token_headers.update({'spotify-app-version': '1.1.48.530.g38509c6c'})
+
+        access_token_url = 'https://open.spotify.com/get_access_token?reason=transport&productType=web_player'
+
+        response = self._session.get(access_token_url, headers=access_token_headers, cookies=self.cj)
+        access_token_response = response.json()
+        self.access_token = access_token_response['accessToken']
+        self.access_token_expire = access_token_response['accessTokenExpirationTimestampMs']
+        self.cj._cookies['.spotify.com']['/']['sp_t'] = response.cookies
+
+        guc_url = f'wss://guc-dealer.spotify.com/?access_token={self.access_token}'
+        guc_headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)'
+                                     ' Chrome/87.0.4280.66 Safari/537.36'}
+
+        self.connection_id = None
+        self.queue_revision = None
+
+        async def websocket():
+            try:
+                async with websockets.connect(guc_url, extra_headers=guc_headers) as ws:
+                    Thread(target=lambda: start_ping_loop(ws)).start()
+                    while True:
+                        recv = await ws.recv()
+                        load = json.loads(recv)
+                        # pprint(load, indent=4)
+                        if load.get('headers'):
+                            if load['headers'].get('Spotify-Connection-Id'):
+                                self.connection_id = load['headers']['Spotify-Connection-Id']
+                        if load.get('payloads'):
+                            try:
+                                if load['payloads'][0].get('cluster'):
+                                    try:
+                                        self.queue = load['payloads'][0]['cluster']['player_state']['next_tracks']
+                                    except KeyError:
+                                        pass
+                                    self.queue_revision = load['payloads'][0]['cluster']['player_state']['queue_revision']
+                                    self.shuffling = (load['payloads'][0]['cluster']['player_state']['options']
+                                    ['shuffling_context'])
+                            except AttributeError:
+                                pass
+            except Exception as exe:
+                print(exe)
+                self._authorize()
+
+        def start_ping_loop(ws):
+            asyncio.new_event_loop().run_until_complete(ping_loop(ws))
+
+        async def ping_loop(ws):
+            while True:
+                await ws.send('{"type": "ping"}')
+                await asyncio.sleep(30)
+
+        Thread(target=lambda: asyncio.new_event_loop().run_until_complete(websocket())).start()
+
+        device_url = 'https://guc-spclient.spotify.com/track-playback/v1/devices'
+        self.device_id = ''.join(random.choices(string.ascii_letters, k=40))
+        while True:
+            if self.connection_id:
+                device_data = {"device": {"brand": "spotify", "capabilities":
+                    {"change_volume": True, "enable_play_token": True,
+                     "supports_file_media_type": True,
+                     "play_token_lost_behavior": "pause",
+                     "disable_connect": True, "audio_podcasts": True,
+                     "video_playback": True,
+                     "manifest_formats": ["file_urls_mp3",
+                                          "manifest_ids_video",
+                                          "file_urls_external",
+                                          "file_ids_mp4",
+                                          "file_ids_mp4_dual"]},
+                                          "device_id": self.device_id, "device_type": "computer",
+                                          "metadata": {}, "model": "web_player", "name": "Spotify Player",
+                                          "platform_identifier": "web_player windows 10;chrome 87.0.4280.66;desktop"},
+                               "connection_id": self.connection_id, "client_version":
+                                   "harmony:4.11.0-af0ef98",
+                               "volume": 65535}
+                break
+
+        device_headers = self._default_headers.copy()
+        device_headers.update({'authorization': f'Bearer {self.access_token}'})
+
+        response = self._session.post(device_url, headers=device_headers, data=json.dumps(device_data))
+        if response.status_code == 200:
+            logging.log(logging.INFO, f'Successfully created Spotify device with id {self.device_id}.')
+
+        notifications_url = f'https://api.spotify.com/v1/me/notifications/user?connection_id={self.connection_id}'
+        notifications_headers = self._default_headers.copy()
+        notifications_headers.update({'Authorization': f'Bearer {self.access_token}'})
+        self._session.put(notifications_url, headers=notifications_headers)
+
+        hobs_url = f'https://guc-spclient.spotify.com/connect-state/v1/devices/hobs_{self.device_id}'
+        hobs_headers = self._default_headers.copy()
+        hobs_headers.update({'authorization': f'Bearer {self.access_token}'})
+        hobs_headers.update({'x-spotify-connection-id': self.connection_id})
+        hobs_data = {"member_type": "CONNECT_STATE", "device": {"device_info":
+                                                                    {"capabilities": {"can_be_player": False,
+                                                                                      "hidden": True}}}}
+        response = self._session.put(hobs_url, headers=hobs_headers, data=json.dumps(hobs_data))
+        try:
+            self.queue = response.json()['player_state']['next_tracks']
+        except Exception as e:
+            self.queue = []
+            logging.error(e, exc_info=True)
+        self.queue_revision = response.json()['player_state']['queue_revision']
+        self.shuffling = response.json()['player_state']['options']['shuffling_context']
+
+    def transfer(self, device_id):
+        transfer_url = f'https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/' \
+                       f'{self.device_id}/to/{device_id}'
+        transfer_headers = self._default_headers.copy()
+        transfer_headers.update({'authorization': f'Bearer {self.access_token}'})
+        transfer_data = {'transfer_options': {'restore_paused': 'restore'}}
+        response = self._session.post(transfer_url, headers=transfer_headers, data=json.dumps(transfer_data))
+        return response
+
+    def command(self, command_dict):
+        headers = {'Authorization': f'Bearer {self.access_token}'}
+        currently_playing_device = self._session.get('https://api.spotify.com/v1/me/player', headers=headers)
+        try:
+            currently_playing_device = currently_playing_device.json()['device']['id']
+        except json.decoder.JSONDecodeError:
+            currently_playing_device = self._session.get('https://api.spotify.com/v1/me/player/devices',
+                                                         headers=headers).json()['devices'][0]['id']
+            response = self.transfer(currently_playing_device)
+            print(response.json())
+            time.sleep(1)
+            currently_playing_device = self._session.get('https://api.spotify.com/v1/me/player', headers=headers)
+            currently_playing_device = currently_playing_device.json()['device']['id']
+        player_url = f'https://guc-spclient.spotify.com/connect-state/v1/player/command/from/{self.device_id}' \
+                     f'/to/{currently_playing_device}'
+        if isinstance(command_dict, list):
+            for command in command_dict:
+                player_data = command
+                player_headers = self._default_headers.copy()
+                player_headers.update({'authorization': f'Bearer {self.access_token}'})
+                response = self._session.post(player_url, headers=headers, data=json.dumps(player_data))
+                if response.status_code != 200:
+                    raise RequestException(f'Command failed: {response.json()}')
+                else:
+                    logging.log(logging.INFO, 'Command executed successfully.')
+        else:
+            if 'url' in command_dict:
+                player_url = command_dict['url'].replace('player', self.device_id).replace('device',
+                                                                                           currently_playing_device)
+                command_dict.pop('url')
+            player_data = command_dict
+            player_headers = self._default_headers.copy()
+            player_headers.update({'authorization': f'Bearer {self.access_token}'})
+            if 'request_type' in player_data:
+                if player_data['request_type'] == 'PUT':
+                    player_data.pop('request_type')
+                    response = self._session.put(player_url, headers=headers, data=json.dumps(player_data))
+                    if response.status_code != 200:
+                        try:
+                            response.json()
+                            raise RequestException(f'Command failed: {response.json()}')
+                        except json.decoder.JSONDecodeError:
+                            pass
+                    else:
+                        logging.log(logging.INFO, 'Command executed successfully.')
+            else:
+                response = self._session.post(player_url, headers=headers, data=json.dumps(player_data))
+                if response.status_code != 200:
+                    try:
+                        response.json()
+                        raise RequestException(f'Command failed: {response.json()}')
+                    except json.decoder.JSONDecodeError:
+                        pass
+                else:
+                    logging.log(logging.INFO, 'Command executed successfully.')
+        time.sleep(0.5)

--- a/experimental.py
+++ b/experimental.py
@@ -237,6 +237,8 @@ class SpotifyPlayer:
 
         async def ping_loop():
             while self.ping:
+                if self.access_token_expire < time.time():
+                    self._authorize()
                 await self.ws.send('{"type": "ping"}')
                 await asyncio.sleep(30)
 
@@ -291,6 +293,8 @@ class SpotifyPlayer:
         self.isinitialized = True
 
     def transfer(self, device_id):
+        if self.access_token_expire < time.time():
+            self._authorize()
         transfer_url = f'https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/' \
                        f'{self.device_id}/to/{device_id}'
         transfer_headers = self._default_headers.copy()
@@ -300,6 +304,8 @@ class SpotifyPlayer:
         return response
 
     def command(self, command_dict):
+        if self.access_token_expire < time.time():
+            self._authorize()
         headers = {'Authorization': f'Bearer {self.access_token}'}
         currently_playing_device = self._session.get('https://api.spotify.com/v1/me/player', headers=headers)
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pynput
 spotipy
 requests
 clipboard
+browser_cookie3
+websockets

--- a/spotlight/commands/device.py
+++ b/spotlight/commands/device.py
@@ -12,12 +12,13 @@ class DeviceCommand(Command):
     """
     Device Command allow's user to view and select available devices to stream on
     """
-    def __init__(self, sp: Spotify):
+    def __init__(self, sp: Spotify, spotifyplayer):
         Command.__init__(self, "Device", "Set the device to play music from", "device")
+        self.spotifyplayer = spotifyplayer
         self.sp = sp
 
     def get_suggestions(self, **kwargs):
         if kwargs["parameter"] != "":  # menu item will not be retrieved if there is text in the parameter str
             return []
         else:
-            return [DeviceMenuSuggestions(self.sp)]
+            return [DeviceMenuSuggestions(self.sp, self.spotifyplayer)]

--- a/spotlight/commands/playing.py
+++ b/spotlight/commands/playing.py
@@ -8,24 +8,26 @@ from spotlight.suggestions.templates import WarningSuggestion, WarningFillSugges
 
 
 class PlayingCommand(Command):
-    def __init__(self, sp: Spotify):
+    def __init__(self, sp: Spotify, spotifyplayer):
         Command.__init__(self, "Currently Playing", "Show currently playing song", "currently playing")
+        self.spotifyplayer = spotifyplayer
         self.sp = sp
 
     def get_suggestions(self, **kwargs):
         if kwargs["parameter"] != "":
             return []
         else:
-            return [SongPlayingSuggestion(self.sp)]
+            return [SongPlayingSuggestion(self.sp, self.spotifyplayer)]
 
 
 class SongPlayingSuggestion(MenuSuggestion):
-    def __init__(self, sp: Spotify):
+    def __init__(self, sp: Spotify, spotifyplayer):
         MenuSuggestion.__init__(self, "Currently Playing", "Show currently playing song", "play", "Currently Playing", [])
         self.sp = sp
+        self.spotifyplayer = spotifyplayer
 
     def refresh_menu_suggestions(self):
-        song = PlaybackFunctions(self.sp).get_current_song_info()
+        song = PlaybackFunctions(self.sp, self.spotifyplayer).get_current_song_info()
         if song["name"] == "Nothing Currently Playing":
             self.menu_suggestions = [WarningFillSuggestion("No active device selected", "Click to select device", "device")]
         else:

--- a/spotlight/handler.py
+++ b/spotlight/handler.py
@@ -21,7 +21,8 @@ class CommandHandler:
     """
     Handles commands and output suggestions for the Spotlight UI
     """
-    def __init__(self, sp: Spotify, queue: Queue):
+    def __init__(self, sp: Spotify, queue: Queue, spotifyplayer):
+        self.spotifyplayer = spotifyplayer
         self.sp = sp
         self.auth_ui = AuthUI()
         # store commands in a list
@@ -40,22 +41,21 @@ class CommandHandler:
                              LikeCommand(sp),
                              RepeatCommand(),
                              ShuffleCommand(sp),
-                             PlayingCommand(sp),
+                             PlayingCommand(sp, spotifyplayer),
                              PreviousCommand(),
                              NextCommand(),
                              PauseCommand(),
                              VolumeCommand(),
                              GoToCommand(),
-                             DeviceCommand(sp),
+                             DeviceCommand(sp, spotifyplayer),
                              SavedCommand(),
                              ShareCommand(),
                              AuthenticationCommand(),
                              ExitCommand()
                              ]
 
-        self.manager = PlaybackManager(sp, queue)
+        self.manager = PlaybackManager(sp, queue, spotifyplayer)
         # TODO create a settings json to store things like default device
-        self.manager.set_device("")  # sets device to first available
         CacheHolder.reload_holder("all")  # Initially loads the cache into memory
 
     def get_command_suggestions(self, text: str) -> list:
@@ -83,7 +83,7 @@ class CommandHandler:
     def perform_command(self, item: Suggestion):
         """
         Executes a command
-        :param command: Suggestion object
+        :param command: Suggestion object n
         """
         try:
             if item.title == "Authentication":  # opens Auth UI, needs changed at some point

--- a/spotlight/handler.py
+++ b/spotlight/handler.py
@@ -83,7 +83,7 @@ class CommandHandler:
     def perform_command(self, item: Suggestion):
         """
         Executes a command
-        :param command: Suggestion object n
+        :param command: Suggestion object
         """
         try:
             if item.title == "Authentication":  # opens Auth UI, needs changed at some point

--- a/spotlight/suggestions/device.py
+++ b/spotlight/suggestions/device.py
@@ -10,12 +10,13 @@ class DeviceMenuSuggestions(MenuSuggestion):
     """
     Device Menu Suggestion, when clicked shows device suggestions
     """
-    def __init__(self, sp: Spotify):
+    def __init__(self, sp: Spotify, spotifyplayer):
         MenuSuggestion.__init__(self, "Device", "Set The device to play music from", "device", "device", [])
+        self.spotifyplayer = spotifyplayer
         self.sp = sp
 
     def refresh_menu_suggestions(self):
-        devices = MiscFunctions(self.sp).get_device_list()
+        devices = MiscFunctions(self.sp, self.spotifyplayer).get_device_list()
         self.clear_menu_suggestions()
         if not devices:
             self.add_menu_suggestion(

--- a/ui/spotlight.py
+++ b/ui/spotlight.py
@@ -16,10 +16,11 @@ class SpotlightUI(QWidget):
     QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)  # enable highdpi scaling
     QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)  # use highdpi icon-base
 
-    def __init__(self, sp: Spotify, song_queue: SongQueue, parent=None):
+    def __init__(self, sp: Spotify, song_queue: SongQueue, spotifyplayer, parent=None):
         QWidget.__init__(self, parent)
         # for spotify interaction
-        self.command_handler = CommandHandler(sp, song_queue)
+        self.spotifyplayer = spotifyplayer
+        self.command_handler = CommandHandler(sp, song_queue, spotifyplayer)
         self.sp = sp
         # row positioning
         self.move(center_app())
@@ -73,7 +74,7 @@ class SpotlightUI(QWidget):
                         }}''')
         self.textbox.setFont(self.custom_font)
         # add grouped widgets
-        self.function_row = FunctionButtonsRow(self, self.sp)
+        self.function_row = FunctionButtonsRow(self, self.sp, self.spotifyplayer)
         self.function_row.move(0, 0)
         self.function_row.show()
         self.toggle_function_buttons()

--- a/ui/widgets.py
+++ b/ui/widgets.py
@@ -10,12 +10,12 @@ from os import sep
 
 
 class FunctionButtonsRow(QWidget):
-    def __init__(self, parent, sp):
+    def __init__(self, parent, sp, spotifyplayer):
         QWidget.__init__(self, parent)
         # creates a useful function object
         self.sp = sp
-        toggles = toggle.ToggleFunctions(sp)
-        playback_change = playback.PlaybackFunctions(sp)
+        toggles = toggle.ToggleFunctions(sp, spotifyplayer)
+        playback_change = playback.PlaybackFunctions(sp, spotifyplayer)
         # gets the current theme
         self.active_theme = parent.active_theme
         # gets the font


### PR DESCRIPTION
What I did:
I looked into the requests the web spotify client was making, and I discovered it's possible to create a fake device that sends requests to the main player, which can control the user's playback. I then integrated this with Spotlightify. More info [here.](https://github.com/CriticalElement/spotify-free-api-player)
What was fixed:
Nothing was fixed, but there was many features added.
Files affected:
I created the experimental.py file (the main spotify player), and changed the commands to work with the new free player commands.
Bugs fixed:
I fixed most of the bugs that occured when implementing this feature, although there is one that I will squash right after I create this pr.
Testing done:
I did testing with every command, and they all worked as expected.
I used Windows 10 Home.