### PR TITLE
Fix pause on application start

### DIFF
--- a/spotlight/handler.py
+++ b/spotlight/handler.py
@@ -55,7 +55,6 @@ class CommandHandler:
 
         self.manager = PlaybackManager(sp, queue)
         # TODO create a settings json to store things like default device
-        self.manager.set_device("")  # sets device to first available
         CacheHolder.reload_holder("all")  # Initially loads the cache into memory
 
     def get_command_suggestions(self, text: str) -> list:


### PR DESCRIPTION
Maybe I'm missing something but setting a default device doesn't seem to make a difference and removing this line stops music from pausing when you start the app.