### PR TITLE
Open Spotlightify at correct position

### DIFF
--- a/backend/constants/constants.go
+++ b/backend/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	Height = 65
+	Width  = 550
+)

--- a/frontend/src/Command/Commands/album.ts
+++ b/frontend/src/Command/Commands/album.ts
@@ -8,6 +8,7 @@ import { CombinedArtistsString } from "./utils";
 import {
   GetAlbumsByQuery,
   PlayAlbum,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 
 class AlbumCommand extends BaseCommand {
@@ -87,7 +88,7 @@ class AlbumCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/artist.ts
+++ b/frontend/src/Command/Commands/artist.ts
@@ -10,6 +10,7 @@ import {
   GetArtistsByQuery,
   PlayAlbum,
   PlayArtistsTopTracks,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 
 class ArtistCommand extends BaseCommand {
@@ -89,7 +90,7 @@ class ArtistCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/play.ts
+++ b/frontend/src/Command/Commands/play.ts
@@ -4,6 +4,7 @@ import Icon from "../../types/icons";
 import {
   GetTracksByQuery,
   PlayTrack,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 import { Hide, Show } from "../../../wailsjs/runtime";
 import icons from "../../types/icons";
@@ -87,7 +88,7 @@ class PlayCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/playlist.ts
+++ b/frontend/src/Command/Commands/playlist.ts
@@ -6,6 +6,7 @@ import {
   GetTracksByQuery,
   PlayPlaylist,
   PlayTrack,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 import { Hide, Show } from "../../../wailsjs/runtime";
 import icons from "../../types/icons";
@@ -88,7 +89,7 @@ class PlaylistCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/podcast.ts
+++ b/frontend/src/Command/Commands/podcast.ts
@@ -7,6 +7,7 @@ import { spotify } from "../../../wailsjs/go/models";
 import {
   GetShowsByQuery,
   PlayPodcast,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 
 class PodcastCommand extends BaseCommand {
@@ -86,7 +87,7 @@ class PodcastCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/queue.ts
+++ b/frontend/src/Command/Commands/queue.ts
@@ -4,6 +4,7 @@ import Icon from "../../types/icons";
 import {
   GetTracksByQuery,
   QueueTrack,
+  ShowWindow,
 } from "../../../wailsjs/go/backend/Backend";
 import { Hide, Show } from "../../../wailsjs/runtime";
 import icons from "../../types/icons";
@@ -87,7 +88,7 @@ class PlayCommand extends BaseCommand {
                 },
               ],
             });
-            Show();
+            ShowWindow();
           }
           return Promise.resolve();
         },

--- a/frontend/src/Command/Commands/utils.ts
+++ b/frontend/src/Command/Commands/utils.ts
@@ -3,6 +3,7 @@ import SimpleArtist = spotify.SimpleArtist;
 import { Suggestion, SuggestionList } from "../../types/command";
 import Icon from "../../types/icons";
 import { Show } from "../../../wailsjs/runtime";
+import { ShowWindow } from "../../../wailsjs/go/backend/Backend";
 
 // TODO: at some point, we should probably move this to the backend for efficiency
 export function CombinedArtistsString(artists: SimpleArtist[]): string {
@@ -33,7 +34,7 @@ export function HandleGenericError(
       },
     ],
   });
-  Show();
+  ShowWindow();
 }
 
 export function DeviceIconSelector(deviceType: string): Icon {

--- a/frontend/wailsjs/go/backend/Backend.d.ts
+++ b/frontend/wailsjs/go/backend/Backend.d.ts
@@ -80,4 +80,6 @@ export function SetAuthenticatedWithSpotify(arg1:boolean):Promise<void>;
 
 export function SetVolume(arg1:number):Promise<void>;
 
+export function ShowWindow():Promise<void>;
+
 export function Shuffle(arg1:boolean):Promise<void>;

--- a/frontend/wailsjs/go/backend/Backend.js
+++ b/frontend/wailsjs/go/backend/Backend.js
@@ -154,6 +154,10 @@ export function SetVolume(arg1) {
   return window['go']['backend']['Backend']['SetVolume'](arg1);
 }
 
+export function ShowWindow() {
+  return window['go']['backend']['Backend']['ShowWindow']();
+}
+
 export function Shuffle(arg1) {
   return window['go']['backend']['Backend']['Shuffle'](arg1);
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"spotlightify-wails/backend"
+	"spotlightify-wails/backend/constants"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -25,8 +26,8 @@ func main() {
 	// Create application with options
 	err := wails.Run(&options.App{
 		Title:             "Spotlightify",
-		Width:             550,
-		Height:            65,
+		Width:             constants.Width,
+		Height:            constants.Height,
 		AlwaysOnTop:       true,
 		DisableResize:     true,
 		HideWindowOnClose: true,


### PR DESCRIPTION
This PR make Spotlightify open at the correct screen position when
the keybinding is triggered.

Issues to solve before merge:
- [x] When `Hide()` wails function is called anywhere in the frontend, the keybind will no longer open the prompt.
  - Solved by calling the `ShowWindow()` wails function instead of `Show()`
