### PR TITLE
Add Liked Songs command

### DIFF
--- a/backend/spotify.go
+++ b/backend/spotify.go
@@ -519,3 +519,25 @@ func (b *Backend) AuthenticateWithSpotify() error {
 func (b *Backend) CloseAuthServer() {
 	b.authServer.StopAuthServer()
 }
+
+func (b *Backend) PlayLiked() {
+	ctx := context.Background()
+	client, err := b.managers.spotifyHolder.GetSpotifyInstance()
+	if err != nil {
+		slog.Error("error getting spotify instance", "error", err)
+		return
+	}
+
+	likedTracks, err := client.CurrentUsersTracks(ctx, spotify.Limit(50))
+	if err != nil {
+		slog.Error("error getting liked tracks", "error", err)
+		return
+	}
+
+	uris := []spotify.URI{}
+	for _, track := range likedTracks.Tracks {
+		uris = append(uris, track.SimpleTrack.URI)
+	}
+
+	client.PlayOpt(ctx, &spotify.PlayOptions{URIs: uris})
+}

--- a/frontend/src/Command/Commands/liked.ts
+++ b/frontend/src/Command/Commands/liked.ts
@@ -1,0 +1,40 @@
+import { Suggestion, SuggestionList } from "../../types/command";
+import { Hide } from "../../../wailsjs/runtime";
+import Icon from "../../types/icons";
+import { PlayLiked } from "../../../wailsjs/go/backend/Backend";
+import { HandleGenericError } from "./utils";
+import BaseCommand from "./baseCommand";
+
+class PlayLikedSongs extends BaseCommand {
+  constructor() {
+    super("liked_songs", "Liked", "liked", 0, "liked songs", {});
+  }
+
+  getSuggestions(
+    input: string,
+    parameters: Record<string, string>
+  ): Promise<SuggestionList> {
+    return Promise.resolve({ items: [] });
+  }
+
+  async getPlaceholderSuggestion(): Promise<Suggestion> {
+    return {
+      title: "Liked Songs",
+      description: "Plays 50 most recently liked songs in your library",
+      icon: Icon.Play,
+      id: this.id,
+      action: async (actions) => {
+        Hide();
+        actions.resetPrompt();
+        try {
+          await PlayLiked();
+        } catch (e) {
+          HandleGenericError("Liked", e, actions.setSuggestionList);
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+}
+
+export default PlayLikedSongs;

--- a/frontend/src/hooks/useCommand.ts
+++ b/frontend/src/hooks/useCommand.ts
@@ -22,6 +22,7 @@ import ExitCommand from "../Command/Commands/exit";
 import ArtistCommand from "../Command/Commands/artist";
 import AuthenticateCommand from "../Command/Commands/authenticate/authenticate";
 import { Hide, WindowHide } from "../../wailsjs/runtime/runtime";
+import PlayLikedSongs from "../Command/Commands/liked";
 
 export interface CommandOptions {
   parameters?: Record<string, string>;
@@ -49,6 +50,7 @@ function useCommand() {
       commandRegistry.register(new AlbumCommand());
       commandRegistry.register(new ArtistCommand());
       commandRegistry.register(new PodcastCommand());
+      commandRegistry.register(new PlayLikedSongs());
 
       // Playback control commands
       commandRegistry.register(new PauseCommand());
@@ -119,7 +121,7 @@ function useCommand() {
         arr.push(item.command.shorthandTitle);
         return arr;
       },
-      [],
+      []
     );
 
     if (activeCommand) {

--- a/frontend/wailsjs/go/backend/Backend.d.ts
+++ b/frontend/wailsjs/go/backend/Backend.d.ts
@@ -60,6 +60,8 @@ export function PlayAlbum(arg1:string):Promise<void>;
 
 export function PlayArtistsTopTracks(arg1:string):Promise<void>;
 
+export function PlayLiked():Promise<void>;
+
 export function PlayPlaylist(arg1:string):Promise<void>;
 
 export function PlayPodcast(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/backend/Backend.js
+++ b/frontend/wailsjs/go/backend/Backend.js
@@ -114,6 +114,10 @@ export function PlayArtistsTopTracks(arg1) {
   return window['go']['backend']['Backend']['PlayArtistsTopTracks'](arg1);
 }
 
+export function PlayLiked() {
+  return window['go']['backend']['Backend']['PlayLiked']();
+}
+
 export function PlayPlaylist(arg1) {
   return window['go']['backend']['Backend']['PlayPlaylist'](arg1);
 }


### PR DESCRIPTION
This PR adds a 'Liked Songs' command which will play the first 50 saved songs for a user. When retrieving a user's saved songs the maximum that can be retrieved is 50 per request therefore I decided only one request should be made to retrieve these songs. This is something that could possibly be enhanced if/when background caching is implemented and we can store all of the users saved songs locally so we do not have to retrieve them from Spotify each time this command is executed.