### PR TITLE
Fix Spotify API changes issue

### DIFF
--- a/backend/spotify.go
+++ b/backend/spotify.go
@@ -49,7 +49,15 @@ func (b *Backend) GetPlaylistsByQuery(query string) ([]spotify.SimplePlaylist, e
 		return []spotify.SimplePlaylist{}, err
 	}
 
-	return results.Playlists.Playlists, nil
+	// Filter out playlists with empty names
+	filteredPlaylists := make([]spotify.SimplePlaylist, 0)
+	for _, playlist := range results.Playlists.Playlists {
+		if playlist.Name != "" {
+			filteredPlaylists = append(filteredPlaylists, playlist)
+		}
+	}
+
+	return filteredPlaylists, nil
 }
 
 func (b *Backend) GetArtistsByQuery(query string) ([]spotify.FullArtist, error) {


### PR DESCRIPTION
This PR fixes an issue that was introduced by changes to Spotify's
API functionality. The issue was that the API does not retrieve
playlists generated by Spotify, so instead of retrieving the data about
these playlists, it would return blank playlists instead. The fact that
the API is returning blank playlists is probably a bug on Spotify's end
and I would it expect it to be fixed quickly anyway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced playlist retrieval by filtering out playlists with empty names, improving the quality of results for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->