### PR TITLE
Small Windows fixes

### DIFF
--- a/backend/internal/constants/constants.go
+++ b/backend/internal/constants/constants.go
@@ -3,7 +3,7 @@ package constants
 import "fmt"
 
 const (
-	Port         = ":49264"
+	Port         = ":9123"
 	ServerURL    = "http://localhost" + Port
 	SpotifyState = "spotlightify-state"
 )

--- a/frontend/src/hooks/useCommand.ts
+++ b/frontend/src/hooks/useCommand.ts
@@ -83,6 +83,11 @@ function useCommand() {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         if (!activeCommand) {
+          actions.batchActions([
+            { type: "CLEAR_COMMANDS" },
+            { type: "SET_PROMPT_INPUT", payload: "" },
+            { type: "SET_SUGGESTION_LIST", payload: { items: [] } },
+          ]);
           WindowHide();
         }
         if (!activeCommandOptions?.lockCommandStack) {


### PR DESCRIPTION
- Change port number for auth server
- Clear prompt on Windows when 'Escape' is pressed
